### PR TITLE
Comparing to Internal Name of Command in void GetCommandType(...)

### DIFF
--- a/Karpach.RemoteShutdown.Controller/Helpers/TrayCommandHelper.cs
+++ b/Karpach.RemoteShutdown.Controller/Helpers/TrayCommandHelper.cs
@@ -39,7 +39,7 @@ namespace Karpach.RemoteShutdown.Controller.Helpers
 
         public TrayCommandType? GetCommandType(string commandName)
         {
-            return Commands.SingleOrDefault(c => string.Equals(c.Name, commandName, StringComparison.InvariantCultureIgnoreCase))?.CommandType;
+            return Commands.SingleOrDefault(c => string.Equals(c.CommandType.ToString(), commandName, StringComparison.InvariantCultureIgnoreCase))?.CommandType;
         }
 
         public void RunCommand(TrayCommandType commandType)

--- a/Karpach.RemoteShutdown.Controller/Karpach.RemoteShutdown.Controller.csproj
+++ b/Karpach.RemoteShutdown.Controller/Karpach.RemoteShutdown.Controller.csproj
@@ -7,6 +7,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Platforms>x64</Platforms>
+	  <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Icons\switch.ico</ApplicationIcon>

--- a/Karpach.RemoteShutdown.Controller/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Karpach.RemoteShutdown.Controller/Properties/PublishProfiles/FolderProfile.pubxml
@@ -10,8 +10,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <SelfContained>false</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
     <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR fixes (what it seems to me) a glitch which causes the URL argument to be invalid on Commands that have spaces in their Display Name.

For example: "Force Shutdown" (Display name) "ForceShutdown" (internal name)

The Documentation states an URL for ForceShutdown to be like this: http://remote-host-name:5001/secret/ForceShutdown

Unfortunately, this doesn't work because the Display name expects a space in between "Force" and "Shutdown".

So this is the URL that actually works in this case: http://remote-host-name:5001/secret/Force%20Shutdown

But my PR is fixing this issue so the Command in the Documentation works as expected. 