### PR TITLE
Fix host startup by properly awaiting StartAsync

### DIFF
--- a/Karpach.RemoteShutdown.Controller/Helpers/HostHelper.cs
+++ b/Karpach.RemoteShutdown.Controller/Helpers/HostHelper.cs
@@ -36,7 +36,7 @@ namespace Karpach.RemoteShutdown.Controller.Helpers
                 await _hostTask.ConfigureAwait(false);
                 _cancellationTokenSource = new CancellationTokenSource();
             }
-            _hostTask = Task.Run(() =>
+            _hostTask = Task.Run(async () =>
             {
                 var host = new WebHostBuilder()
                     .UseUrls($"http://+:{port}")
@@ -52,7 +52,7 @@ namespace Karpach.RemoteShutdown.Controller.Helpers
                         });
                     })
                     .Build();
-                host.StartAsync(_cancellationTokenSource.Token);                
+                await host.StartAsync(_cancellationTokenSource.Token);
             }, _cancellationTokenSource.Token);
         }
 


### PR DESCRIPTION
The web host was not starting correctly because StartAsync() was called without being awaited inside Task.Run. This caused the task to complete immediately without waiting for the host to actually start, potentially leaving the HTTP server in an uninitialized state.

Changes:
- Made Task.Run lambda async to support await
- Added await to host.StartAsync() call

This ensures the host is fully started before CreateHostAsync completes.

